### PR TITLE
Separator visual change to match State0 with State1 and latter

### DIFF
--- a/CommandSender/PropertyInspector/PluginActionPI.html
+++ b/CommandSender/PropertyInspector/PluginActionPI.html
@@ -45,7 +45,7 @@
         </div>
         
         <div id="State1" style="display: none">
-            <br>State1</br>
+            <br>------------------------------State1------------------------------</br>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Communication Type</div>
                 <select class="sdpi-item-value select sdProperty" id="communicationMode1" oninput="updateSettings()">
@@ -72,7 +72,7 @@
         </div>
 
         <div id="State2" style="display: none">
-            <br>State2</br>
+            <br>------------------------------State2------------------------------</br>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Communication Type</div>
                 <select class="sdpi-item-value select" id="CommunicationMode2" oninput="updateSettings()">
@@ -99,7 +99,7 @@
         </div>
 
         <div id="State3" style="display: none">
-            <br>State3</br>
+            <br>------------------------------State3------------------------------</br>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Communication Type</div>
                 <select class="sdpi-item-value select" id="CommunicationMode3" oninput="updateSettings()">
@@ -126,7 +126,7 @@
         </div>
 
         <div id="State4" style="display: none">
-            <br>State4</br>
+            <br>------------------------------State4------------------------------</br>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Communication Type</div>
                 <select class="sdpi-item-value select" id="CommunicationMode4" oninput="updateSettings()">
@@ -153,7 +153,7 @@
         </div>
 
         <div id="State5" style="display: none">
-            <br>State5</br>
+            <br>------------------------------State5------------------------------</br>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Communication Type</div>
                 <select class="sdpi-item-value select" id="CommunicationMode5" oninput="updateSettings()">
@@ -180,7 +180,7 @@
         </div>
 
         <div id="State6" style="display: none">
-            <br>State6</br>
+            <br>------------------------------State6------------------------------</br>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Communication Type</div>
                 <select class="sdpi-item-value select" id="CommunicationMode6" oninput="updateSettings()">
@@ -207,7 +207,7 @@
         </div>
 
         <div id="State7" style="display: none">
-            <br>State7</br>
+            <br>------------------------------State7------------------------------</br>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Communication Type</div>
                 <select class="sdpi-item-value select" id="CommunicationMode7" oninput="updateSettings()">
@@ -234,7 +234,7 @@
         </div>
 
         <div id="State8" style="display: none">
-            <br>State8</br>
+            <br>------------------------------State8------------------------------</br>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Communication Type</div>
                 <select class="sdpi-item-value select" id="CommunicationMode8" oninput="updateSettings()">
@@ -261,7 +261,7 @@
         </div>
 
         <div id="State9" style="display: none">
-            <br>State9</br>
+            <br>------------------------------State9------------------------------</br>
             <div class="sdpi-item">
                 <div class="sdpi-item-label">Communication Type</div>
                 <select class="sdpi-item-value select" id="CommunicationMode9" oninput="updateSettings()">


### PR DESCRIPTION
Hi @Zayik, your CommandSender is really helping me a lot everyday.
Thank you for developing great plugin!

Today I made a little cosmetic fix for the state separator.
I prefer how the State0 separator look, so I changed State1 separator and latter.
There should be no functional change to the plugin itself.

Unfortunately I don't have a dedicated environment to compile the project,
so this pull request only contains changes to the html file and thus doesn't include the working plugin.

I'd really appreciate if you will consider this small patch to be included in the future.
Thank you!